### PR TITLE
Add emoji reaction tips.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -431,8 +431,6 @@ async def _tip(ctx, amount, user: discord.User=None):
     self_exists = session.query(Wallet).filter(Wallet.userid == user.id).first()
     tipees = ctx.message.mentions
 
-    num_users = len(tipees)
-
     if not self_exists:
         err_embed.description = "You haven't registered a wallet!"
         err_embed.add_field(name="Help", value="Use `{}registerwallet <addr>` before trying to tip!".format(config['prefix']))

--- a/config.json.example
+++ b/config.json.example
@@ -3,13 +3,16 @@
   "prefix":".", # use something like ! , . ~ ` ?
   "coin": "Turtlecoin",
   "symbol": "TRTL", 
+  "tip_amp_emoji": "tip",
   # faucet address if configured
   "faucet": "TRTLv14M1Q9223QdWMmJyNeY8oMjXs5TGP9hDc3GJFsUVdXtaemn1mLKA25Hz9PLu89uvDafx9A93jW2i27E5Q3a7rn8P2fLuVA", # url to faucet
   "price_source": "TradeOgre", # name to display in price command
   "price_endpoint": "https://tradeogre.com/api/v1/ticker/BTC-TRTL", # api price source
   "units": 100, # number of decimal places
+  "daemon_host": "127.0.0.1",
   "daemon_port": "11898",
   "rpc_password":"turtlecoinonly",
+  "rpc_host": "127.0.0.1",
   "rpc_port":"8070"
 }
 


### PR DESCRIPTION
ux flow is as follows:

 1. user does tip, it is successful.
 2. user 2 reacts with `:tip:` emoji
 3. user 2 amplifies the tip and tips the same amount as the original.

extra rules:

 - you can't amplifiy your own tip
 - you can only amplify with `:tip:`
 - you can only join a successful tip (after the bot adds `:moneybags:`)
 - you can only amplify once, multiple attempts are ignored.

crummy bits:

the bot can't maintain state between launches. if the bot crashes, the reaction watcher isn't listening to reactions on messages before the bot loads.

some quick code cleanup
 - removed unused imports
 - corrected bunch of spacing inconsistencies